### PR TITLE
[URLShortener] Fix duplicate 'www' prefix in shortened URLs

### DIFF
--- a/pages/api/urlshortener.ts
+++ b/pages/api/urlshortener.ts
@@ -12,14 +12,12 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method === "POST") {
-    console.log("hi");
-    const { longUrl } = req.body;
-
+    let { longUrl } = req.body;
+    longUrl = longUrl.replace(/^https:\/\/(www\.)?/, ""); // Removes 'https://' or 'https://www.' if present
     if (!longUrl) {
       res.status(400).json({ error: true, message: "Missing longUrl" });
       return;
     }
-
     const isLongAvailable = await isLongUrlExists(longUrl);
 
     if (!isLongAvailable.error) {
@@ -28,6 +26,7 @@ export default async function handler(
 
     try {
       const shortUrl = await generateShortUrl(longUrl);
+      console.log("shortUrl", shortUrl);
       const newUrl = await prisma.url.create({
         data: {
           longUrl,


### PR DESCRIPTION
fix: resolve duplicate 'www' prefix in shortened URLs

- Trimmed 'www.' and 'https://www.' prefix from input URLs to prevent duplication in the shortened URL.
- Ensured correct redirection for URLs with and without 'www' prefix.

fixes #40 